### PR TITLE
fix: rename artifactId from java-packageable-base, docs cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -108,7 +108,7 @@ public class DisplayListSystem implements EcsSystem {
 mvn compile              # Compile only
 mvn exec:java            # Run during development
 mvn clean package        # Build JAR with dependencies
-java -jar target/java-packageable-base-1.0-SNAPSHOT-jar-with-dependencies.jar
+java -jar target/console-jack-1.0-SNAPSHOT-jar-with-dependencies.jar
 ```
 
 ### Platform Packaging

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Console Jack is a console-based, text-graphics implementation of the classic cas
 - `mvn compile` - Compile the project
 - `mvn exec:java` - Run the application directly
 - `mvn clean package` - Build JAR with dependencies
-- `java -jar target/java-packageable-base-1.0-SNAPSHOT-jar-with-dependencies.jar` - Run the packaged JAR
+- `java -jar target/console-jack-1.0-SNAPSHOT-jar-with-dependencies.jar` - Run the packaged JAR
 
 ### Platform-Specific Packaging
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Console Jack
 
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Console-based, text-graphics implementation of the classic casino blackjack game.
 
 Aims to be a "Card RPG" of sorts where you start a career as a frequent player at a local casino, and "move up the ranks" to the top-tier casinos of the world. All of that, in ASCII text-graphics, terminal-emulator-driven glory.
@@ -25,7 +27,7 @@ Currently in semi-active development (_read: I have a day job, so I work on this
 ### Running the Game
 ```bash
 # Clone and build
-git clone <repository-url>
+git clone https://github.com/luxsolari/console-jack
 cd console-jack
 mvn compile
 
@@ -39,7 +41,7 @@ mvn exec:java
 mvn clean package
 
 # Run the packaged version
-java -jar target/java-packageable-base-1.0-SNAPSHOT-jar-with-dependencies.jar
+java -jar target/console-jack-1.0-SNAPSHOT-jar-with-dependencies.jar
 ```
 
 ## Tech Stack
@@ -109,4 +111,4 @@ src/main/java/net/luxsolari/
 3. Test changes with `mvn exec:java`
 4. Verify build with `mvn clean package`
 
-See `docs/IMPROVEMENT_PLAN.md` for planned enhancements and `docs/CLAUDE.md` for detailed development guidance.
+See [`docs/README.md`](docs/README.md) for the full documentation index — architecture, engine guides, and `CLAUDE.md` for AI-assistant development guidance.

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -47,7 +47,7 @@ mvn clean compile
 mvn clean package
 
 # Test the packaged version
-java -jar target/java-packageable-base-1.0-SNAPSHOT-jar-with-dependencies.jar
+java -jar target/console-jack-1.0-SNAPSHOT-jar-with-dependencies.jar
 ```
 
 ## Build Commands Reference
@@ -69,7 +69,7 @@ mvn exec:java -Dexec.args="--debug"  # Pass arguments
 ```bash
 mvn package                   # Create JAR with dependencies
 mvn clean package             # Clean build
-java -jar target/java-packageable-base-1.0-SNAPSHOT-jar-with-dependencies.jar
+java -jar target/console-jack-1.0-SNAPSHOT-jar-with-dependencies.jar
 ```
 
 ### Platform-Specific Builds

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,11 @@ This directory contains all project documentation for Console Jack.
 - **[RIPER_MODE.md](RIPER_MODE.md)** - RIPER-5 mode strict operational protocol
 - **[DEVELOPER_GUIDE.md](DEVELOPER_GUIDE.md)** - Comprehensive development guide
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** - Detailed architecture documentation
+- **[ECS_GUIDE.md](ECS_GUIDE.md)** - Entity Component System guide
+- **[RENDERING_GUIDE.md](RENDERING_GUIDE.md)** - Rendering system guide
+- **[INPUT_SYSTEM_GUIDE.md](INPUT_SYSTEM_GUIDE.md)** - Input system guide
+- **[AUDIO_SYSTEM_GUIDE.md](AUDIO_SYSTEM_GUIDE.md)** - Audio system guide
+- **[STATE_MACHINE_GUIDE.md](STATE_MACHINE_GUIDE.md)** - State machine guide
 - **[UI_COMPONENTS_GUIDE.md](UI_COMPONENTS_GUIDE.md)** - UI component framework reference
 - **[IMPROVEMENT_PLAN.md](IMPROVEMENT_PLAN.md)** - Planned enhancements and technical debt
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.luxsolari</groupId>
-    <artifactId>java-packageable-base</artifactId>
+    <artifactId>console-jack</artifactId>
     <version>1.0-SNAPSHOT</version>
 
     <properties>


### PR DESCRIPTION
## Summary
Fresh-eyes review, same process applied to sage-instructor, three-axes-framework, lux-solari-plugins, and claude-trip-computer.

`pom.xml`'s artifactId was still literally `java-packageable-base` -- the name of a different template repo this one was bootstrapped from -- referenced consistently (if consistently wrong) across `pom.xml`, `README.md`, `CLAUDE.md`, `docs/DEVELOPER_GUIDE.md`, and `.github/copilot-instructions.md`. Renamed to `console-jack` everywhere. The packaging profiles (windows/mac/linux) all reference `${project.build.finalName}`, so this is a safe, single-point change.

Also fixed:
- `<repository-url>` placeholder never filled in.
- Root README linked to a nonexistent `docs/CLAUDE.md` -- pointed to `docs/README.md`'s index instead.
- `docs/README.md`'s own doc index was missing 5 of 13 files in that folder.
- Added a license badge.

GitHub topics added separately.

## Test plan
- [x] `pom.xml` validated as well-formed XML
- [x] CI (`maven.yml`) will build the project on this PR since it triggers on `develop`
- [x] Confirmed no other references to `java-packageable-base` remain anywhere in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)